### PR TITLE
Remove empty styles field in main app component

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,7 +5,6 @@ import { Component } from '@angular/core';
   template: `
     <game-board></game-board>
   `,
-  styles: []
 })
 export class AppComponent {
   title = 'ng-tetris';


### PR DESCRIPTION
Remove redundant `styles` field, because no inline styles for main app component provided.